### PR TITLE
Add shared dir to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "generators/new-wp-plugin",
     "generators/new-wp-project",
     "generators/new-wp",
-    "generators/php-lib"
+    "generators/php-lib",
+    "shared"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
  Fix a bug with the `shared` dir dependencies.
- **What is the current behavior?** 
  #17
- **What is the new behavior (if this is a feature change)?**
  Shared dir should be downloaded also when installing the package from npm.
- **Does this PR introduce a breaking change?** 
  No
- **Other information**:
