### PR TITLE
Allow to install plugin only on production - Fix #35

### DIFF
--- a/generators/new-wp-project/templates/composer.json
+++ b/generators/new-wp-project/templates/composer.json
@@ -8,19 +8,17 @@
     "moxie/gravity-forms-logging": "dev-master",
     "moxie/wp-migrate-db-pro": "dev-master",
     "moxie/wp-migrate-db-pro-media-files": "dev-master",
-    "moxie/wp-migrate-db-pro-cli": "dev-master",
-    "yoast/wordpress-seo": "*",
+    "wpackagist-plugin/rest-api": "dev-trunk",
+    "wpackagist-plugin/regenerate-thumbnails": "*"
+  },
+  "require-dev": {
+    "yoast/wordpress-seo": "^3.2",
     "wpackagist-plugin/stream": "*",
-    "wpackagist-plugin/regenerate-thumbnails": "*",
     "wpackagist-plugin/wp-help": "*",
     "wpackagist-plugin/broken-link-checker": "*",
     "wpackagist-plugin/postmark-approved-wordpress-plugin": "*",
     "wpackagist-plugin/mainwp-child": "*",
-    "wpackagist-plugin/akismet": "*",
-    "wpackagist-plugin/rest-api": "dev-trunk"
-  },
-  "script": {
-    "post-update-cmd": "cd wp-content/plugins/wordpress-seo && composer install"
+    "wpackagist-plugin/akismet": "*"
   },
   "authors": [
     {

--- a/generators/new-wp-project/templates/travis.yml
+++ b/generators/new-wp-project/templates/travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 install:
   - composer self-update;
-  - composer install;
+  - composer install --no-dev;
 
 cache:
   directories:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Allow to install only the required plugins to run development.
- **What is the current behavior?** (You can also link to an open issue
  here)
#35
- **What is the new behavior (if this is a feature change)?**

Allow to just install the required plugins with: 

``` bash
composer install --no-dev
```
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No, keeps working as always when running `composer install`
